### PR TITLE
future 0.18.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.18.2" %}
+{% set version = "0.18.3" %}
 
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/f/future/future-{{ version }}.tar.gz
-  sha256: b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d
+  sha256: 34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307
 
 build:
   number: 1


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 1820f44..90dfeee 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.18.2" %}
+{% set version = "0.18.3" %}
 
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/f/future/future-{{ version }}.tar.gz
-  sha256: b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d
+  sha256: 34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307
 
 build:
   number: 1

```

**Jira ticket:** []() (-)

**The upstream data:**
Github releases:  https://github.com/PythonCharmers/python-future/releases
[Diff between the latest and previous upstream releases](https://github.com/PythonCharmers/python-future/compare/0.18.2...0.18.3)
License: https://github.com/PythonCharmers/python-future/blob/master/LICENSE.txt
Requirements:
 * setup.cfg:  https://github.com/PythonCharmers/python-future/blob/v0.18.3/setup.cfg
 * setup.py:  https://github.com/PythonCharmers/python-future/blob/v0.18.3/setup.py

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: anaconda | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 0.18.3
 * Release on PyPi:
    * version: 0.18.3
    * date: 2023-01-13T03:15:17
* [PyPi history](https://pypi.org/project/future/#history)
 * Popularity: 
    * 3 months downloads: 856486.0
    * All time:  10214552 downloads -  future  0.18.3  Clean single-source support for Python 3 and 2  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/PythonCharmers/python-future/tree/v0.18.3 exists
2. - [ ] The upstream url error:
    http://python-future.org
    
The home url must have HTTPS!
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/PythonCharmers/python-future/tree/v0.18.3
    200
5. - [ ] Additional research
    https://github.com/PythonCharmers/python-future/issues
    
6. - [ ] `dev_url` error:
    https://github.com/PythonCharmers/python-future
    
7. - [ ] `doc_url` error:
    http://python-future.org
    
The doc_url must have HTTPS!
8. - [ ] Verify that the `build_number` is correct
9. - [ ] Verify if the package needs `setuptools`
    
10. - [ ] Verify if the package needs `wheel`
    
11. - [ ] NO `pip` in test
    
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE.txt is present

16. - [x] license_family MIT is present
17. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |
</details>

**Check dependency issues:**

<details>
../aggregate/future-feedstock/recipe/meta.yaml
Dependencies: ['pip', 'python']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 18**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/future-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/future-feedstock/tree/0.18.3)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/future)
* [Diff between upstream and feature branch](https://github.com/conda-forge/future-feedstock/compare/main...AnacondaRecipes:0.18.3)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/future-feedstock/compare/master...AnacondaRecipes:0.18.3)
* [The last merged PRs](https://github.com/AnacondaRecipes/future-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 0.18.3 git@github.com:AnacondaRecipes/future-feedstock.git
```
