### PR TITLE
Update `future`  to version `1.18.3`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ test:
     - pip
 
 about:
-  home: http://python-future.org
+  home: https://python-future.org
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
@@ -45,7 +45,7 @@ about:
     Python-future  is the missing compatibility layer between Python 2 and
     Python 3. It allows you to use a single, clean Python 3.x-compatible
     codebase to support both Python 2 and Python 3 with minimal overhead.
-  doc_url: http://python-future.org
+  doc_url: https://python-future.org
   dev_url: https://github.com/PythonCharmers/python-future
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,12 +27,8 @@ requirements:
 test:
   commands:
     - pip check
-    - futurize -h
-    - pasteurize -h
   imports:
     - future
-    - libfuturize
-    - libpasteurize
     - past
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,8 @@ requirements:
 
 test:
   commands:
+    - futurize -h
+    - pasteurize -h
     - pip check
   imports:
     - future

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.18.2" %}
+{% set version = "0.18.3" %}
 
 
 package:
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/f/future/future-{{ version }}.tar.gz
-  sha256: b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d
+  sha256: 34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307
 
 build:
-  number: 1
+  number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
   entry_points:
     - futurize = libfuturize.main:main
@@ -19,17 +19,23 @@ build:
 requirements:
   host:
     - python
+    - setuptools
     - pip
   run:
     - python
 
 test:
   commands:
+    - pip check
     - futurize -h
     - pasteurize -h
-
   imports:
     - future
+    - libfuturize
+    - libpasteurize
+    - past
+  requires:
+    - pip
 
 about:
   home: http://python-future.org


### PR DESCRIPTION
`future` version `0.18.3`
1. - [X] Check the upstream
    https://github.com/PythonCharmers/python-future/tree/v0.18.3
2. - [X] Check the pinnings
3. - [X] Check the changelogs
    https://github.com/PythonCharmers/python-future/blob/v0.18.3/docs/whatsnew.rst

4. - [X] Additional research
    https://github.com/conda-forge/future-feedstock/issues
    
       There are currently no open issues mentioned at the time of the review in conda forge

5. - [X] Verify the `dev_url`
    https://github.com/PythonCharmers/python-future
6. - [X] Verify the `doc_url`
    http://python-future.org
    
    The `doc_url` seems to have issues an eye must be kept on the package until a new `doc_url` is specified

7. - [X] License is `spdx` compliant
    MIT
8. - [X] License family is present
    MIT
9. - [X] Verify that the `build_number` is correct
10. - [X] Verify if the package needs `setuptools`
    
11. - [X] Verify if the package needs `wheel`
    Wheel does not seem to be mentioned
12. - [X] `pip` in the test section
    pip
13. - [X] Veriy the test section
14. - [X] Verify if the package is `architecture specific` or `Noarch`
15. - [X] Verify that private modules are not mentioned on the recipe For example: (_private_module)
 
Results:
- 
 
 
Based on the research findings and the results we can conclude
that it is safe to update `future` to version `0.18.3`
