### PR TITLE
update to 1.0.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.18.2" %}
+{% set version = "1.0.0" %}
 
 
 package:
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/f/future/future-{{ version }}.tar.gz
-  sha256: b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d
+  sha256: bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05
 
 build:
-  number: 1
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vv --no-build-isolation
   entry_points:
     - futurize = libfuturize.main:main
     - pasteurize = libpasteurize.main:main
@@ -20,19 +20,26 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 
 test:
-  commands:
-    - futurize -h
-    - pasteurize -h
-
   imports:
     - future
+    - libfuturize
+    - libpasteurize
+    - past
+  commands:
+    - pip check
+    - futurize --help
+    - pasteurize --help
+  requires:
+    - pip
 
 about:
-  home: http://python-future.org
+  home: https://python-future.org
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
@@ -41,7 +48,7 @@ about:
     Python-future  is the missing compatibility layer between Python 2 and
     Python 3. It allows you to use a single, clean Python 3.x-compatible
     codebase to support both Python 2 and Python 3 with minimal overhead.
-  doc_url: http://python-future.org
+  doc_url: https://python-future.org
   dev_url: https://github.com/PythonCharmers/python-future
 
 extra:


### PR DESCRIPTION
future 1.0.0

**Destination channel:** main

### Links

- PKG-5964
- https://github.com/PythonCharmers/python-future/tree/v1.0.0
- https://github.com/PythonCharmers/python-future/releases

### Explanation of changes:

- This release is still not 3.13 compatible.
